### PR TITLE
Update ibm_3270.md

### DIFF
--- a/ibm_3270.md
+++ b/ibm_3270.md
@@ -51,6 +51,10 @@ sudo su - $USER
 c3270
 ```
 
+And to connect, just type: 
+
+connect Y:[hostname]:<port>
+
 ### Linux
 
 ```sh


### PR DESCRIPTION
Adicionada string de conexão para o host 3270, ignorando o erro de certificado que pode eventualmente ser apresentado quando o host exige conexão encriptada (ssl).